### PR TITLE
make lxc-images support LXD/LXC 2.0

### DIFF
--- a/lxc-images.sh
+++ b/lxc-images.sh
@@ -23,6 +23,6 @@ mkdir -p "${TUNASYNC_WORKING_DIR}/streams/v1"
 wget -c -T5 -O "${TUNASYNC_WORKING_DIR}/streams/v1/index.json" "${BASE_URL}/streams/v1/index.json"
 
 jq -r '.index.images.path' "${TUNASYNC_WORKING_DIR}/streams/v1/index.json" | while read line; do
-    [ ! -d "$(dirname $line)" ] && mkdir -p "$(dirname $line)"
+    [ ! -d "${TUNASYNC_WORKING_DIR}/$(dirname $line)" ] && mkdir -p "${TUNASYNC_WORKING_DIR}/$(dirname $line)"
     wget -c -T5 -O "${TUNASYNC_WORKING_DIR}/${line}" "${BASE_URL}/${line}"
 done

--- a/lxc-images.sh
+++ b/lxc-images.sh
@@ -22,7 +22,7 @@ wget -c -T5 -O "${TUNASYNC_WORKING_DIR}/meta/1.0/index-user" "${BASE_URL}/meta/1
 mkdir -p "${TUNASYNC_WORKING_DIR}/streams/v1"
 wget -c -T5 -O "${TUNASYNC_WORKING_DIR}/streams/v1/index.json" "${BASE_URL}/streams/v1/index.json"
 
-jq -r '.index.images.path' "${TUNASYNC_WORKING_DIR}/streams/v1/index.json" | while read line; do
+jq -r '.index[].path' "${TUNASYNC_WORKING_DIR}/streams/v1/index.json" | while read line; do
     [ ! -d "${TUNASYNC_WORKING_DIR}/$(dirname $line)" ] && mkdir -p "${TUNASYNC_WORKING_DIR}/$(dirname $line)"
     wget -c -T5 -O "${TUNASYNC_WORKING_DIR}/${line}" "${BASE_URL}/${line}"
 done

--- a/lxc-images.sh
+++ b/lxc-images.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# requires: lftp wget
+# requires: lftp wget jq
 
 BASE_URL="${TUNASYNC_UPSTREAM_URL:-"http://images.linuxcontainers.org/"}"
 
@@ -16,5 +16,13 @@ function sync_lxc_images() {
 sync_lxc_images "${BASE_URL}/images" "${TUNASYNC_WORKING_DIR}/images"
 
 mkdir -p "${TUNASYNC_WORKING_DIR}/meta/1.0"
-wget -O "${TUNASYNC_WORKING_DIR}/meta/1.0/index-system" "${BASE_URL}/meta/1.0/index-system"
-wget -O "${TUNASYNC_WORKING_DIR}/meta/1.0/index-user" "${BASE_URL}/meta/1.0/index-user"
+wget -c -T5 -O "${TUNASYNC_WORKING_DIR}/meta/1.0/index-system" "${BASE_URL}/meta/1.0/index-system"
+wget -c -T5 -O "${TUNASYNC_WORKING_DIR}/meta/1.0/index-user" "${BASE_URL}/meta/1.0/index-user"
+
+mkdir -p "${TUNASYNC_WORKING_DIR}/streams/v1"
+wget -c -T5 -O "${TUNASYNC_WORKING_DIR}/streams/v1/index.json" "${BASE_URL}/streams/v1/index.json"
+
+jq -r '.index.images.path' "${TUNASYNC_WORKING_DIR}/streams/v1/index.json" | while read line; do
+    [ ! -d "$(dirname $line)" ] && mkdir -p "$(dirname $line)"
+    wget -c -T5 -O "${TUNASYNC_WORKING_DIR}/${line}" "${BASE_URL}/${line}"
+done


### PR DESCRIPTION
增加同步`lxc-images`目录下的`streams`目录的相关文件，以支持`LXD/LXC 2.0`。

修改`wget`参数增加`-c -T5`，支持续传与重试(`-c`参数续传，`-T5`代表超时时间5秒，超时则重试)