### PR TITLE
Update hackage.sh:Hackage uses 01-index.tar.gz now

### DIFF
--- a/hackage.sh
+++ b/hackage.sh
@@ -98,6 +98,7 @@ function hackage_mirror() {
 	done
 
 	cp index.tar.gz 01-index.tar.gz
+	ln -sf 01-index.tar.gz 00-index.tar.gz
 }
 
 function cleanup () {

--- a/hackage.sh
+++ b/hackage.sh
@@ -49,7 +49,7 @@ function hackage_mirror() {
 
 	echo "Downloading index..."
 	rm index.tar.gz || true
-	wget "${base_url}/packages/index.tar.gz" -O index.tar.gz &> /dev/null
+	wget "${base_url}/01-index.tar.gz" -O index.tar.gz &> /dev/null
 	
 	echo "building local package list"
 	local tmp
@@ -97,7 +97,7 @@ function hackage_mirror() {
 		rm "package/$name"
 	done
 
-	cp index.tar.gz 00-index.tar.gz
+	cp index.tar.gz 01-index.tar.gz
 }
 
 function cleanup () {


### PR DESCRIPTION
Hackage had a structural change(from 00-index.tar.gz to 01-index.tar.gz), which the current script does not handle correctly.
I'm not sure if this does all the job.