### PR TITLE
anaconda.py: delete unuseful variable

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -185,7 +185,7 @@ def main():
         try:
             sync_repo(remote_url, local_dir, Path(tmpdir))
         except Exception:
-            logging.exception("Failed to sync repo: {}/{}".format(repo, arch))
+            logging.exception("Failed to sync repo: {}".format(repo))
         finally:
             shutil.rmtree(tmpdir)
 


### PR DESCRIPTION
Since CONDA_CLOUD_REPOS defines channel and arch name, so delete unuseful arch variable