### PR TITLE
hackage新的安全机制需要增加同步若干json文件

### DIFF
--- a/hackage.sh
+++ b/hackage.sh
@@ -50,6 +50,14 @@ function hackage_mirror() {
 	echo "Downloading index..."
 	rm index.tar.gz || true
 	wget "${base_url}/01-index.tar.gz" -O index.tar.gz &> /dev/null
+
+	# https://hackage.haskell.org/api#security
+	echo "Dowloading security features..."
+	jsons=("timestamp.json" "snapshot.json" "root.json" "mirrors.json")
+	for name in "${jsons[@]}"
+	do
+    		wget "${base_url}/${name}" -O ${name}
+	done
 	
 	echo "building local package list"
 	local tmp


### PR DESCRIPTION
根据 https://github.com/tuna/mirror-web/issues/132 ，需要同步一些`json`文件来满足stack package-indices新的安全机制。

尚不清楚增加后是否能完全解决问题，也不太了解同步脚本怎么测试（平时基本不写shell）...抛砖引玉，希望尽快解决

---
These `json` files are required for stack 2.1.1. 

Refs:

* https://docs.haskellstack.org/en/stable/yaml_configuration/#package-indices
* https://hackage.haskell.org/api#security