### PR TITLE
Add numba with the dev label for the win-64 channel

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -48,7 +48,7 @@ CONDA_CLOUD_REPOS = (
     "psi4/linux-64", "psi4/osx-64", "psi4/win-64", "psi4/noarch",
     "Paddle/linux-64", "Paddle/linux-32", "Paddle/osx-64", "Paddle/win-64", "Paddle/win-32", "Paddle/noarch",
     "deepmodeling/linux-64", "deepmodeling/noarch",
-    "numba/linux-64", "numba/linux-32", "numba/osx-64", "numba/win-64", "numba/win-32", "numba/noarch",
+    "numba/linux-64", "numba/linux-32", "numba/osx-64", "numba/win-64", "numba/win-32", "numba/noarch", "numba/label/dev/win-64"
 )
 
 EXCLUDED_PACKAGES = (


### PR DESCRIPTION
To add cudatoolkit 9.2 package for Windows
Related issue: https://github.com/tuna/issues/issues/637#event-2746439188