### PR TITLE
下载AdoptOpenJDK的installer

### DIFF
--- a/adoptopenjdk.sh
+++ b/adoptopenjdk.sh
@@ -7,32 +7,55 @@ BASE_PATH="${TUNASYNC_WORKING_DIR}"
 # 参数为版本，比如8,11等
 function downloadRelease() {
   curl -s "https://api.adoptopenjdk.net/v2/latestAssets/releases/openjdk$1" | \
-    jq -r '.[]| [.version,.binary_type,.architecture,.os,.binary_name,.binary_link,.checksum_link]| @tsv' | \
-    while IFS=$'\t' read -r version binary_type architecture os binary_name binary_link checksum_link; do
+    jq -r '.[]| [.version,.binary_type,.architecture,.os,.binary_name,.binary_link,.checksum_link,.installer_name,.installer_link,.installer_checksum_link]| @tsv' | \
+    while IFS=$'\t' read -r version binary_type architecture os binary_name binary_link checksum_link installer_name installer_link installer_checksum_link; do
       mkdir -p "$BASE_PATH/$version/$binary_type/$architecture/$os/" || true
       dest_filename="$BASE_PATH/$version/$binary_type/$architecture/$os/$binary_name"
       declare downloaded=false
       if [[ -f $dest_filename ]]; then
-	    echo "Skiping $binary_name"
-		downloaded=true
+        echo "Skiping $binary_name"
+        downloaded=true
       fi
       while [[ $downloaded != true ]]; do
-		echo "Downloading ${dest_filename}"
-        rm "${dest_filename}" "${dest_filename}.sha256.txt" 2>/dev/null || true
-        rm "${dest_filename}.tmp" "${dest_filename}.sha256.txt.tmp" 2>/dev/null || true
-        curl -s -S --fail -L ${CURL_OPTIONS:-}  \
-          -o "${dest_filename}.tmp" \
-          "$binary_link"
-        curl -s -S --fail -L ${CURL_OPTIONS:-}  \
-          -o "${dest_filename}.sha256.txt.tmp" \
-          "$checksum_link"
-        sha256sum_check && {
-          mv "${dest_filename}.sha256.txt.tmp" "${dest_filename}.sha256.txt"
-		  mv "${dest_filename}.tmp" "${dest_filename}"
-	      downloaded=true
+        echo "Downloading ${dest_filename}"
+        link="$binary_link"
+        download_and_check && {
+	        downloaded=true
         }
       done
+      if [[ -z $installer_name ]]; then
+        dest_filename="$BASE_PATH/$version/$binary_type/$architecture/$os/$installer_name"
+        downloaded=false
+        if [[ -f $dest_filename ]]; then
+          echo "Skiping $installer_name"
+          downloaded=true
+        fi
+        while [[ $downloaded != true ]]; do
+          echo "Downloading ${dest_filename}"
+          link="$installer_link"
+          checksum_link="$installer_checksum_link"
+          download_and_check && {
+            downloaded=true
+          }
+        done
+      fi
     done
+}
+
+function download_and_check() {
+  rm "${dest_filename}" "${dest_filename}.sha256.txt" 2>/dev/null || true
+  rm "${dest_filename}.tmp" "${dest_filename}.sha256.txt.tmp" 2>/dev/null || true
+  curl -s -S --fail -L ${CURL_OPTIONS:-}  \
+    -o "${dest_filename}.tmp" \
+    "$link"
+  curl -s -S --fail -L ${CURL_OPTIONS:-}  \
+    -o "${dest_filename}.sha256.txt.tmp" \
+    "$checksum_link"
+  sha256sum_check && {
+    mv "${dest_filename}.sha256.txt.tmp" "${dest_filename}.sha256.txt"
+    mv "${dest_filename}.tmp" "${dest_filename}"
+    return 0
+  }
 }
 
 function sha256sum_check() {


### PR DESCRIPTION
比如文件`OpenJDK11U-jdk_x86-32_windows_hotspot_11.0.6_10.msi`，现在没有下载。

