### PR TITLE
adoptopenjdk目录分版本

### DIFF
--- a/adoptopenjdk.sh
+++ b/adoptopenjdk.sh
@@ -7,10 +7,10 @@ BASE_PATH="${TUNASYNC_WORKING_DIR}"
 # 参数为版本，比如8,11等
 function downloadRelease() {
   curl -s "https://api.adoptopenjdk.net/v2/latestAssets/releases/openjdk$1" | \
-    jq -r '.[]| [.version,.binary_type,.architecture,.os,.binary_name,.binary_link,.checksum_link,.installer_name,.installer_link,.installer_checksum_link]| @tsv' | \
-    while IFS=$'\t' read -r version binary_type architecture os binary_name binary_link checksum_link installer_name installer_link installer_checksum_link; do
-      mkdir -p "$BASE_PATH/$version/$binary_type/$architecture/$os/" || true
-      dest_filename="$BASE_PATH/$version/$binary_type/$architecture/$os/$binary_name"
+    jq -r '.[]| [.version,.version_data.semver,.binary_type,.architecture,.os,.binary_name,.binary_link,.checksum_link,.installer_name,.installer_link,.installer_checksum_link]| @tsv' | \
+    while IFS=$'\t' read -r version semver binary_type architecture os binary_name binary_link checksum_link installer_name installer_link installer_checksum_link; do
+      mkdir -p "$BASE_PATH/$version/$semver/$binary_type/$architecture/$os/" || true
+      dest_filename="$BASE_PATH/$version/$semver/$binary_type/$architecture/$os/$binary_name"
       declare downloaded=false
       if [[ -f $dest_filename ]]; then
         echo "Skiping $binary_name"
@@ -24,7 +24,7 @@ function downloadRelease() {
         }
       done
       if [[ ! -z "$installer_name" ]]; then
-        dest_filename="$BASE_PATH/$version/$binary_type/$architecture/$os/$installer_name"
+        dest_filename="$BASE_PATH/$version/$semver/$binary_type/$architecture/$os/$installer_name"
         downloaded=false
         if [[ -f $dest_filename ]]; then
           echo "Skiping $installer_name"


### PR DESCRIPTION
现在11.0.6_10和将来的11.0.7_01都会出现在目录<https://mirrors.tuna.tsinghua.edu.cn/AdoptOpenJDK/11/jdk/x64/windows/>下，用户很难判断哪个是最新版本；而且一个目录下太多文件，对文件系统也不友好。

所以目录结构调整为：

`"$BASE_PATH/$version/$semver/$binary_type/$architecture/$os/$installer_name"`

其中semver为具体的版本号，比如`11.0.6+10`