### PR TITLE
julia mirror

### DIFF
--- a/dockerfiles/julia/Dockerfile
+++ b/dockerfiles/julia/Dockerfile
@@ -1,3 +1,8 @@
+# For the details and usage of this docker script, please refer to:
+# * https://github.com/tuna/tunasync-scripts/pull/71
+# * https://github.com/tuna/issues/issues/837
+
+# jill.py requires at least Python 3.6
 FROM python:3.6
 LABEL description="A community maintained docker script to set up julia mirror easily."
 LABEL maintainer="Johnny Chen <johnnychen94@hotmail.com>"
@@ -6,13 +11,21 @@ ENV JULIA_DEPOT_PATH="/tmp/julia"
 ENV JULIA_STATIC_DIR="/julia/static"
 ENV JULIA_CLONES_DIR="/julia/clones"
 
+# jill.py provides two functionalities:
+#   1) mirror julia binary releases
+#   2) install julia in one line
+# FYI: the jill API is quite stable so the version doesn't matter much (it could be okay to set >=0.6.9)
 RUN pip install --upgrade pip && \
-    pip install jill==0.6.8 && \
+    pip install jill==0.6.9 && \
     pip cache purge
 
+# StorageServer.jl is used to set up a *static* storage server for julia packages, it requires at least Julia 1.4
+# The details of the storage protocol can be found in https://github.com/JuliaLang/Pkg.jl/issues/1377
 RUN jill install 1.4 --confirm
 
-WORKDIR /julia
+# StorageServer.jl is an experimental toolkit and it won't be registered in General
+# The API is likely to be changed in the future, so we fix the version here for stability consideration
 RUN julia -e 'using Pkg; pkg"add https://github.com/johnnychen94/StorageServer.jl#v0.1.0-beta.1"'
 
+WORKDIR /julia
 CMD /bin/bash

--- a/dockerfiles/julia/Dockerfile
+++ b/dockerfiles/julia/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.6
+LABEL description="A community maintained docker script to set up julia mirror easily."
+LABEL maintainer="Johnny Chen <johnnychen94@hotmail.com>"
+
+ENV JULIA_DEPOT_PATH="/tmp/julia"
+ENV JULIA_STATIC_DIR="/julia/static"
+ENV JULIA_CLONES_DIR="/julia/clones"
+
+RUN pip install --upgrade pip && \
+    pip install jill==0.6.8 && \
+    pip cache purge
+
+RUN jill install 1.4 --confirm
+
+WORKDIR /julia
+RUN julia -e 'using Pkg; pkg"add https://github.com/johnnychen94/StorageServer.jl#v0.1.0-beta.1"'
+
+CMD /bin/bash


### PR DESCRIPTION
针对[[镜像请求] Julia：General registry](https://github.com/tuna/issues/issues/837)，用docker封装了一个julia镜像工具 

不是很清楚tunasync-scripts是怎么被调用的，这里大概介绍一下手动执行的方式

build: `docker build dockerfiles/julia julia-mirror`

[[镜像请求] Julia：General registry](https://github.com/tuna/issues/issues/837) 中请求了两类数据的镜像：General registry 以及 Julia binary releases

**假设所有相关的数据存放在 `/julia_mirrors` 文件夹下**，最终得到的文件夹结构大概为：

```text
julia_mirrors/
├── clones # git repo mirrors，每次更新都需要，但是不需要对外提供
├── registries # 存放需要镜像的注册表，每次更新都需要，不需要对外提供
│   └── General
└── static # 所有需要对外提供的资源均在 static 文件夹内
    ├── artifact # 装包时所需要的二进制依赖
    ├── package # julia 包的源代码
	├── releases # julia 二进制安装程序
	│	├── latest
	│	├── v1.0
	│	├── v1.1
	│	├── v1.2
	│	├── v1.3
	│	└── v1.4
    ├── registries # 记录当前最新的注册表版本
    └── registry # 注册表数据
```

假设对外提供的url为`https://mirrors.tuna.tsinghua.edu.cn/julia`, 那么 `curl https://mirrors.tuna.tsinghua.edu.cn/julia/registries` 得到的就是 `julia_mirrors /static/registries`的内容

下面是简单的使用说明，应该只需要修改docker的路径映射`-v`就可以了

# 注册表

以`General`为例：

1. 第一次需要先将General clone下来：

```
git clone https://github.com/JuliaRegistries/General.git /julia_mirrors/registries/General
```
2. 以`pkg.julialang.org`作为上游，拉取 `General` 下所有包的资源

```bash
# 注意：Dockerfile里 workdir 被切换到了 /julia 下，所以不需要修改 mirror_tarball 的内容
docker run -it --rm -e JULIA_NUM_THREADS=4 -v /julia_mirrors:/julia julia-mirror \ 
     julia -e 'using StorageServer; mirror_tarball("registries/General", ["pkg.julialang.org"])'
```

其中通过环境变量`JULIA_NUM_THREADS`来分配4个线程进行下载. 这个的日志只能通过重定向来得到（不太确定docker下怎么进行重定向）

更新周期：上游 General 的更新是15分钟一次，可以适当降低频率（例如4或6个小时一次）

在拉取General的时候会遇到一些warning，这是正常现象。这是因为有一些不可控的因素，比如：一些包在注册到General之后被作者删除或者私有化了，一些资源的url失效了

# Julia 二进制安装程序

上游为官方aws s3 bucket：

* 稳定版：`https://julialang-s3.julialang.org`
* nightly builds: `https://julialangnightlies-s3.julialang.org`

```bash
docker run -it --rm -e DEBUG=1 -v /julia_mirrors:/julia julia-mirror \ 
    jill mirror --outdir=static --upstream=Official --logfile=releases.log
```

其中通过环境变量`DEBUG=1`来打印更多的输出信息

更新周期：每天一次即可（默认包括了nightly build)

cc: @Harry-Chen