### PR TITLE
add https protocol prefix to julia upstream

### DIFF
--- a/julia.sh
+++ b/julia.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-BASE_URL=${TUNASYNC_UPSTREAM_URL:-"pkg.julialang.org"}
+BASE_URL=${TUNASYNC_UPSTREAM_URL:-"https://pkg.julialang.org"}
 [[ -d "${TUNASYNC_WORKING_DIR}" ]]
 cd "${TUNASYNC_WORKING_DIR}"
 


### PR DESCRIPTION
Cont. 61e6c6b359576a8bfa573482277ac56ee3a6d048

我看了一下[同步状态](https://mirrors.bfsu.edu.cn/status/#syncing-status)好像所有的上游都带有协议前缀，所以这里给 Julia 的上游补上 https 前缀