### PR TITLE
[julia mirror] use StorageServer#v0.1.0.beta and remove jill dependency

### DIFF
--- a/dockerfiles/julia/Dockerfile
+++ b/dockerfiles/julia/Dockerfile
@@ -2,30 +2,24 @@
 # * https://github.com/tuna/tunasync-scripts/pull/71
 # * https://github.com/tuna/issues/issues/837
 
-# jill.py requires at least Python 3.6
-FROM python:3.6
+# StorageServer.jl is used to set up a *static* storage server for julia packages, it requires at least Julia 1.4
+# The details of the storage protocol can be found in https://github.com/JuliaLang/Pkg.jl/issues/1377
+FROM julia:1.4
 LABEL description="A community maintained docker script to set up julia mirror easily."
 LABEL maintainer="Johnny Chen <johnnychen94@hotmail.com>"
+
+RUN apt-get update && \
+    apt-get install -y \
+        git && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV JULIA_DEPOT_PATH="/tmp/julia"
 ENV JULIA_STATIC_DIR="/julia/static"
 ENV JULIA_CLONES_DIR="/julia/clones"
 
-# jill.py provides two functionalities:
-#   1) mirror julia binary releases
-#   2) install julia in one line
-# FYI: the jill API is quite stable so the version doesn't matter much (it could be okay to set >=0.6.9)
-RUN pip install --upgrade pip && \
-    pip install jill==0.6.9 && \
-    pip cache purge
-
-# StorageServer.jl is used to set up a *static* storage server for julia packages, it requires at least Julia 1.4
-# The details of the storage protocol can be found in https://github.com/JuliaLang/Pkg.jl/issues/1377
-RUN jill install 1.4 --confirm
-
 # StorageServer.jl is an experimental toolkit and it won't be registered in General
 # The API is likely to be changed in the future, so we fix the version here for stability consideration
-RUN julia -e 'using Pkg; pkg"add https://github.com/johnnychen94/StorageServer.jl#v0.1.0-beta.1"'
+RUN julia -e 'using Pkg; pkg"add https://github.com/johnnychen94/StorageServer.jl#v0.1.0-beta"'
 
 RUN chown -R 2000 /tmp/julia/
 

--- a/julia.sh
+++ b/julia.sh
@@ -6,5 +6,9 @@ cd "${TUNASYNC_WORKING_DIR}"
 
 export JULIA_STATIC_DIR="$PWD/static"
 export JULIA_CLONES_DIR="$PWD/clones"
+
+# update and mirror the General registry
+git -C registries/General fetch --all
+git -C registries/General reset --hard origin/master
 exec julia -e "using StorageServer; mirror_tarball(\"registries/General\", [\"$BASE_URL\"])"
 


### PR DESCRIPTION
似乎 `julia-releases` 并没有使用 `jill` 作为镜像工具，所以这里移除了 `jill` 的依赖，直接使用官方提供的 `julia:1.4` 镜像

StorageServer `v0.1.0.beta` 的更新：

* bug修复：在更新过程中正常移除一些本应该被移除的临时文件。
* 将预处理(更新 general repo）和后处理过程（`rm /tmp/jl_*`)从`mirror_tarball`里移除了。其中预处理转移到 `julia.sh` 中了，后处理则因为是个临时的docker容器所以不需要了。（算是修复了同步错误的bug: https://github.com/tuna/issues/issues/837#issuecomment-635008614)

另外，这里需要手动清理一次`static`文件夹下的临时文件：

```
find "$PWD/static" -name '*.tmp.*' -delete;
```

cc: @z4yx 