### PR TITLE
[julia] skip packages that unexpectedly take a long time

### DIFF
--- a/dockerfiles/julia/Dockerfile
+++ b/dockerfiles/julia/Dockerfile
@@ -19,7 +19,7 @@ ENV JULIA_CLONES_DIR="/julia/clones"
 
 # StorageServer.jl is an experimental toolkit and it won't be registered in General
 # The API is likely to be changed in the future, so we fix the version here for stability consideration
-RUN julia -e 'using Pkg; pkg"add https://github.com/johnnychen94/StorageServer.jl#v0.1.0-beta"'
+RUN julia -e 'using Pkg; pkg"add https://github.com/johnnychen94/StorageServer.jl#v0.1.0-rc1"'
 
 RUN chown -R 2000 /tmp/julia/
 

--- a/julia.sh
+++ b/julia.sh
@@ -7,8 +7,12 @@ cd "${TUNASYNC_WORKING_DIR}"
 export JULIA_STATIC_DIR="$PWD/static"
 export JULIA_CLONES_DIR="$PWD/clones"
 
+# timeout (seconds) for individual package instead of the whole mirror process
+# initialization should use a larger timeout, e.g., 7200
+PKG_TIMEOUT=600
+
 # update and mirror the General registry
 git -C registries/General fetch --all
 git -C registries/General reset --hard origin/master
-exec julia -e "using StorageServer; mirror_tarball(\"registries/General\", [\"$BASE_URL\"])"
+exec julia -e "using StorageServer; mirror_tarball(\"registries/General\", [\"$BASE_URL\"]; timeout=$PKG_TIMEOUT)"
 


### PR DESCRIPTION
这里的超时策略是：如果某个包（包括所有版本）的拉取过程超过了`PKG_TIMEOUT`，那么就跳过这个包的拉取，继续下一个包。对于增量更新来说，10分钟应该是一个比较宽松的值。

Julia Pkg 在装包时若上游镜像站缺少某一资源，会使用原始地址作为fallback，所以即使增量更新不完整，在大范围内不会太影响整体的使用。