### PR TITLE
update julia upstream

### DIFF
--- a/julia.sh
+++ b/julia.sh
@@ -9,7 +9,7 @@ export JULIA_CLONES_DIR="$PWD/clones"
 
 # timeout (seconds) for individual package instead of the whole mirror process
 # initialization should use a larger timeout, e.g., 7200
-PKG_TIMEOUT=600
+PKG_TIMEOUT=1800
 
 # update and mirror the General registry
 git -C registries/General fetch --all

--- a/julia.sh
+++ b/julia.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-BASE_URL=${TUNASYNC_UPSTREAM_URL:-"https://pkg.julialang.org"}
+BASE_URL=${TUNASYNC_UPSTREAM_URL:-"https://us-east.storage.julialang.org"}
 [[ -d "${TUNASYNC_WORKING_DIR}" ]]
 cd "${TUNASYNC_WORKING_DIR}"
 


### PR DESCRIPTION
`https://us-east.storage.julialang.org` 是静态HTTP服务器，是反代形式的`https://pkg.julialang.org`(Pkg Server) 的存储上游。最近PkgServer的改变比较大，可能是导致 https://github.com/tuna/issues/issues/866 的一个原因，但不太确定是否因为如此，仅仅作为一个尝试。

Edit: 我们这边内网服务器连接 `https://us-east.storage.julialang.org` 的网络并不十分好，但我猜 BFSU 应该不会存在这个问题？