### PR TITLE
[Julia] upgrade julia mirror script

### DIFF
--- a/dockerfiles/julia/Dockerfile
+++ b/dockerfiles/julia/Dockerfile
@@ -8,7 +8,7 @@ FROM julia:1.4
 LABEL description="A community maintained docker script to set up julia mirror easily."
 LABEL maintainer="Johnny Chen <johnnychen94@hotmail.com>"
 
-RUN julia -e 'using Pkg; pkg"add https://github.com/johnnychen94/StorageMirrorServer.jl#v0.1.0-rc8"'
+RUN julia -e 'using Pkg; pkg"add https://github.com/johnnychen94/StorageMirrorServer.jl#v0.1.1-rc3"'
 
 RUN chown -R 2000 /tmp/julia/
 

--- a/dockerfiles/julia/Dockerfile
+++ b/dockerfiles/julia/Dockerfile
@@ -8,18 +8,7 @@ FROM julia:1.4
 LABEL description="A community maintained docker script to set up julia mirror easily."
 LABEL maintainer="Johnny Chen <johnnychen94@hotmail.com>"
 
-RUN apt-get update && \
-    apt-get install -y \
-        git && \
-    rm -rf /var/lib/apt/lists/*
-
-ENV JULIA_DEPOT_PATH="/tmp/julia"
-ENV JULIA_STATIC_DIR="/julia/static"
-ENV JULIA_CLONES_DIR="/julia/clones"
-
-# StorageServer.jl is an experimental toolkit and it won't be registered in General
-# The API is likely to be changed in the future, so we fix the version here for stability consideration
-RUN julia -e 'using Pkg; pkg"add https://github.com/johnnychen94/StorageServer.jl#v0.1.0-rc1"'
+RUN julia -e 'using Pkg; pkg"add https://github.com/johnnychen94/StorageMirrorServer.jl#v0.1.0-rc8"'
 
 RUN chown -R 2000 /tmp/julia/
 

--- a/julia.sh
+++ b/julia.sh
@@ -1,18 +1,16 @@
 #!/bin/bash
 set -e
-BASE_URL=${TUNASYNC_UPSTREAM_URL:-"https://us-east.storage.julialang.org"}
+BASE_URL=${TUNASYNC_UPSTREAM_URL:-"https://us-east.storage.juliahub.com"}
 [[ -d "${TUNASYNC_WORKING_DIR}" ]]
 cd "${TUNASYNC_WORKING_DIR}"
 
-export JULIA_STATIC_DIR="$PWD/static"
-export JULIA_CLONES_DIR="$PWD/clones"
+OUTPUT_DIR="$PWD/static"
 
-# timeout (seconds) for individual package instead of the whole mirror process
-# initialization should use a larger timeout, e.g., 7200
-PKG_TIMEOUT=1800
+REGISTRY_NAME="General"
+REGISTRY_UUID="23338594-aafe-5451-b93e-139f81909106"
+REGISTRY_UPSTREAM="https://github.com/JuliaRegistries/General"
+REGISTRY="(\"$REGISTRY_NAME\", \"$REGISTRY_UUID\", \"$REGISTRY_UPSTREAM\")"
 
-# update and mirror the General registry
-git -C registries/General fetch --all
-git -C registries/General reset --hard origin/master
-exec julia -e "using StorageServer; mirror_tarball(\"registries/General\", [\"$BASE_URL\"]; timeout=$PKG_TIMEOUT)"
-
+# For more usage of `mirror_tarball`, please refer to
+# https://github.com/johnnychen94/StorageMirrorServer.jl/blob/master/examples/gen_static_full.example.jl
+exec julia -e "using StorageMirrorServer; mirror_tarball($REGISTRY, [\"$BASE_URL\"], \"$OUTPUT_DIR\")"


### PR DESCRIPTION
address #80

我bash下手动执行是ok的，不过不是特别确定这个在tunasync下是不是能正常跑...

如果需要的话可以改成 https://kr.storage.juliahub.com （韩国首尔）作为上游