### PR TITLE
[Julia] print relevant information when starting julia jobs

### DIFF
--- a/julia.sh
+++ b/julia.sh
@@ -12,7 +12,7 @@ REGISTRY_UPSTREAM="https://github.com/JuliaRegistries/General"
 REGISTRY="(\"$REGISTRY_NAME\", \"$REGISTRY_UUID\", \"$REGISTRY_UPSTREAM\")"
 
 julia -e "using InteractiveUtils; versioninfo(); @show DEPOT_PATH LOAD_PATH"
-julia -e "using Pkg; Pkg.status(\"StorageMirrorServer\")"
+julia -e "using Pkg; Pkg.status()"
 
 # For more usage of `mirror_tarball`, please refer to
 # https://github.com/johnnychen94/StorageMirrorServer.jl/blob/master/examples/gen_static_full.example.jl

--- a/julia.sh
+++ b/julia.sh
@@ -11,6 +11,9 @@ REGISTRY_UUID="23338594-aafe-5451-b93e-139f81909106"
 REGISTRY_UPSTREAM="https://github.com/JuliaRegistries/General"
 REGISTRY="(\"$REGISTRY_NAME\", \"$REGISTRY_UUID\", \"$REGISTRY_UPSTREAM\")"
 
+julia -e "using InteractiveUtils; versioninfo(); @show DEPOT_PATH LOAD_PATH"
+julia -e "using Pkg; Pkg.status(\"StorageMirrorServer\")"
+
 # For more usage of `mirror_tarball`, please refer to
 # https://github.com/johnnychen94/StorageMirrorServer.jl/blob/master/examples/gen_static_full.example.jl
 exec julia -e "using StorageMirrorServer; mirror_tarball($REGISTRY, [\"$BASE_URL\"], \"$OUTPUT_DIR\")"


### PR DESCRIPTION
Example output:

```bash
test@77d93412dab5:~$ julia -e "using InteractiveUtils; versioninfo(); @show DEPOT_PATH LOAD_PATH"
Julia Version 1.5.0
Commit 96786e22cc (2020-08-01 23:44 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: Intel(R) Xeon(R) E-2124 CPU @ 3.30GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-9.0.1 (ORCJIT, skylake)
Environment:
  JULIA_GPG = 3673DF529D9049477F76B37566E3C7DC03D6E495
  JULIA_VERSION = 1.5.0
  JULIA_DEPOT_PATH = /opt/julia
  JULIA_PATH = /usr/local/julia
DEPOT_PATH = ["/home/test/.julia", "/opt/julia"]
LOAD_PATH = ["@", "@v#.#", "@stdlib", "/opt/julia"]
test@77d93412dab5:~$ julia -e "using Pkg; Pkg.status()"
Status `/opt/julia/environments/v1.5/Project.toml`
  [c599abfa] StorageMirrorServer v0.1.1-rc3 `https://github.com/johnnychen94/StorageMirrorServer.jl#v0.1.1-rc3`
```

Cref: #81 