### PR TITLE
[Julia] make registry downloading failure a panic

### DIFF
--- a/dockerfiles/julia/Dockerfile
+++ b/dockerfiles/julia/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="Johnny Chen <johnnychen94@hotmail.com>"
 ENV JULIA_DEPOT_PATH="/opt/julia"
 
 RUN adduser --uid 2000 tunasync && \
-    julia -e 'using Pkg; pkg"add https://github.com/johnnychen94/StorageMirrorServer.jl#v0.1.1-rc3"' && \
+    julia -e 'using Pkg; pkg"add https://github.com/johnnychen94/StorageMirrorServer.jl#v0.1.1-rc4"' && \
     chmod a+rx -R $JULIA_DEPOT_PATH
 
 COPY dockerfiles/julia/startup.jl /usr/local/julia/etc/julia/startup.jl


### PR DESCRIPTION
现在会直接抛出一个错误，这样的话bash会把它识别为同步失败

```bash
# with timeout 5s
root@storage:~/docker/julia-mirror# julia gen_static.jl 
┌ Warning: ErrorException("type Nothing has no field status")
│   resource = "/registry/23338594-aafe-5451-b93e-139f81909106/65102b89ec1830985bc80d699c1564f6a78a1977"
└ @ StorageMirrorServer ~/.julia/packages/StorageMirrorServer/4Vvsm/src/mirror_tarball.jl:67
┌ Error: failed to fetch registry tarball
│   uuid = "23338594-aafe-5451-b93e-139f81909106"
│   hash = "65102b89ec1830985bc80d699c1564f6a78a1977"
│   upstreams =
│    1-element Array{String,1}:
│     "https://kr.storage.juliahub.com"
└ @ StorageMirrorServer ~/.julia/packages/StorageMirrorServer/4Vvsm/src/mirror_tarball.jl:86
ERROR: LoadError: Stop mirroring.
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] mirror_tarball(::StorageMirrorServer.RegistryMeta, ::Array{String,1}, ::String; http_parameters::Dict{Symbol,Any}, packages::Array{Any,1}, show_progress::Bool) at /root/.julia/packages/StorageMirrorServer/4Vvsm/src/mirror_tarball.jl:87
 [3] #mirror_tarball#48 at /root/.julia/packages/StorageMirrorServer/4Vvsm/src/mirror_tarball.jl:24 [inlined]
 [4] top-level scope at /root/docker/julia-mirror/gen_static.jl:51
 [5] include(::Function, ::Module, ::String) at ./Base.jl:380
 [6] include(::Module, ::String) at ./Base.jl:368
 [7] exec_options(::Base.JLOptions) at ./client.jl:296
 [8] _start() at ./client.jl:506
in expression starting at /root/docker/julia-mirror/gen_static.jl:50
```

Cref: https://github.com/tuna/tunasync-scripts/issues/80#issuecomment-671413322