### PR TITLE
[julia] upgrade to StorageMirrorServer v0.1.4 and use all official upstreams

### DIFF
--- a/dockerfiles/julia/Dockerfile
+++ b/dockerfiles/julia/Dockerfile
@@ -11,10 +11,14 @@ LABEL maintainer="Johnny Chen <johnnychen94@hotmail.com>"
 ENV JULIA_DEPOT_PATH="/opt/julia"
 
 RUN adduser --uid 2000 tunasync && \
-    julia -e 'using Pkg; pkg"add https://github.com/johnnychen94/StorageMirrorServer.jl#v0.1.1-rc4"' && \
+    julia -e 'using Pkg; pkg"add StorageMirrorServer@0.1.4"' && \
     chmod a+rx -R $JULIA_DEPOT_PATH
 
-COPY dockerfiles/julia/startup.jl /usr/local/julia/etc/julia/startup.jl
+# Julia doesn't not yet have a nice solution for centralized package system with preinstalled
+# packages. Here we provide a system-wide startup.jl that modifies the DEPOT_PATH and LOAD_PATH
+# variables for each user.
+# For more information about this, please refer to https://github.com/JuliaLang/Pkg.jl/issues/1952
+COPY startup.jl /usr/local/julia/etc/julia/startup.jl
 
 WORKDIR /julia
 CMD /bin/bash

--- a/dockerfiles/julia/startup.jl
+++ b/dockerfiles/julia/startup.jl
@@ -1,3 +1,10 @@
+# makes /opt/julia a shared depot path so that users can directly find and load
+# pre-installed packages
+#
+# For non-root users, /opt/julia is read-only, trying to add packages would be impossible.
+# A workaround for this is to start julia with a project folder that is writable, e.g.,
+# `julia --project=$HOME/.julia/env/1.5"`
+
 SHARE_DIR = "/opt/julia"
 
 empty!(DEPOT_PATH)

--- a/julia.sh
+++ b/julia.sh
@@ -4,6 +4,8 @@ BASE_URL=${TUNASYNC_UPSTREAM_URL:-"https://us-east.storage.juliahub.com"}
 [[ -d "${TUNASYNC_WORKING_DIR}" ]]
 cd "${TUNASYNC_WORKING_DIR}"
 
+UPSTREAMS="[\"https://us-east.storage.juliahub.com\", \"https://kr.storage.juliahub.com\"]"
+
 OUTPUT_DIR="$PWD/static"
 
 REGISTRY_NAME="General"
@@ -13,4 +15,4 @@ REGISTRY="(\"$REGISTRY_NAME\", \"$REGISTRY_UUID\", \"$REGISTRY_UPSTREAM\")"
 
 # For more usage of `mirror_tarball`, please refer to
 # https://github.com/johnnychen94/StorageMirrorServer.jl/blob/master/examples/gen_static_full.example.jl
-exec julia -e "using StorageMirrorServer; mirror_tarball($REGISTRY, [\"$BASE_URL\"], \"$OUTPUT_DIR\")"
+exec julia -e "using StorageMirrorServer; mirror_tarball($REGISTRY, $UPSTREAMS, \"$OUTPUT_DIR\")"


### PR DESCRIPTION
关于之前失败的版本 (#84) 的更新：

* 完善了异常处理和日志输出
* 多上游情况下，会从第一个返回HEAD请求的上游下载数据
* 最近上游非常不稳定，调大了默认的 timeout 值


Cref: #80