### PR TITLE
[Julia] skip failed_resources for 5 days until the next try

### DIFF
--- a/dockerfiles/julia/Dockerfile
+++ b/dockerfiles/julia/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="Johnny Chen <johnnychen94@hotmail.com>"
 ENV JULIA_DEPOT_PATH="/opt/julia"
 
 RUN adduser --uid 2000 tunasync && \
-    julia -e 'using Pkg; pkg"add StorageMirrorServer@0.1.5"' && \
+    julia -e 'using Pkg; pkg"add StorageMirrorServer@0.1.6"' && \
     chmod a+rx -R $JULIA_DEPOT_PATH
 
 # Julia doesn't not yet have a nice solution for centralized package system with preinstalled

--- a/dockerfiles/julia/Dockerfile
+++ b/dockerfiles/julia/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="Johnny Chen <johnnychen94@hotmail.com>"
 ENV JULIA_DEPOT_PATH="/opt/julia"
 
 RUN adduser --uid 2000 tunasync && \
-    julia -e 'using Pkg; pkg"add StorageMirrorServer@0.1.4"' && \
+    julia -e 'using Pkg; pkg"add StorageMirrorServer@0.1.5"' && \
     chmod a+rx -R $JULIA_DEPOT_PATH
 
 # Julia doesn't not yet have a nice solution for centralized package system with preinstalled

--- a/julia.sh
+++ b/julia.sh
@@ -15,4 +15,4 @@ REGISTRY="(\"$REGISTRY_NAME\", \"$REGISTRY_UUID\", \"$REGISTRY_UPSTREAM\")"
 
 # For more usage of `mirror_tarball`, please refer to
 # https://github.com/johnnychen94/StorageMirrorServer.jl/blob/master/examples/gen_static_full.example.jl
-exec julia -e "using StorageMirrorServer; mirror_tarball($REGISTRY, $UPSTREAMS, \"$OUTPUT_DIR\")"
+exec julia -e "using StorageMirrorServer; mirror_tarball($REGISTRY, $UPSTREAMS, \"$OUTPUT_DIR\", skip_duration=120)"


### PR DESCRIPTION
`failed_resources.txt`里面包括的是下载失败的资源：有一些是因为网络原因无法下载，更多的是因为在上游第一次构建的时候源数据URL就已经失效了。单独为这些维护一个 `block_resources.txt` 意义不大，所以设置一个大一点的时间间隔来避免无意义地尝试 `failed_resources.txt`。目前观察下来的下载成功率还蛮高的，所以应该不会有太大问题。

每次增量更新所需的大概时间：

* 尝试 `failed_resources.txt` ：大概20-30分钟
* 不尝试：没有遇到大的artifacts的话，2分钟左右；如果遇到大的artifacts的话就得慢慢耗了

目前观察到的大概是139个无效资源，以及4个下载失败

Cref: #80 