### PR TITLE
[julia] upgrade to StorageMirrorServer v0.2.0

### DIFF
--- a/dockerfiles/julia/Dockerfile
+++ b/dockerfiles/julia/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="Johnny Chen <johnnychen94@hotmail.com>"
 ENV JULIA_DEPOT_PATH="/opt/julia"
 
 RUN adduser --uid 2000 tunasync && \
-    julia -e 'using Pkg; pkg"add StorageMirrorServer@0.1.6"' && \
+    julia -e 'using Pkg; pkg"add StorageMirrorServer@0.2.0"' && \
     chmod a+rx -R $JULIA_DEPOT_PATH
 
 # Julia doesn't not yet have a nice solution for centralized package system with preinstalled


### PR DESCRIPTION
HTTP.jl is somehow not reliable enough that `HTTP.get` would occasionally hang for unidentified reasons as we've seen all through the initialization of julia mirror. This version uses `curl` instead of `HTTP.get` to fetch resources, which is more stable and faster.

`curl` dependency is included in julia:1.5 base image so we don't need to install it.