### PR TITLE
Add Stellarium to github-release

### DIFF
--- a/github-release.py
+++ b/github-release.py
@@ -39,6 +39,7 @@ REPOS = [
     "llvm/llvm-project",
     "conda-forge/miniforge",
     "texstudio-org/texstudio",
+    "Stellarium/stellarium",
 ]
 
 # connect and read timeout value


### PR DESCRIPTION
Refer to [#999](https://github.com/tuna/issues/issues/999).

There is no license information for `stellarium-data`, hence not included in this PR.

For DSS data, they are too big and infrequently used (maybe) hence not included in this PR.