### PR TITLE
Add nvidia channel in anaconda

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -63,6 +63,7 @@ CONDA_CLOUD_REPOS = (
     "c4aarch64/linux-aarch64", "c4aarch64/noarch",
     "pytorch3d/linux-64", "pytorch3d/noarch",
     "idaholab/linux-64", "idaholab/noarch",
+    "nvidia/linux-64", "nvidia/noarch",
 )
 
 EXCLUDED_PACKAGES = (


### PR DESCRIPTION
参考 https://github.com/tuna/issues/issues/1083 ，可知 nvidia channel 中的 cudatoolkit 与 defaults 中的有所区别。

由于 conda 需要管理依赖，手动安装 cudatoolkit 较为困难。

其余与 nvidia anaconda 有关的请求
https://github.com/tuna/issues/issues/1042 ，此 issue 中未考虑到 conda 的依赖管理问题
https://github.com/tuna/issues/issues/410 ，此 issue 关注镜像 nvidia 本身，对 nvidia anaconda 有一定参考价值

此 PR 需要相关人员的讨论。