### PR TITLE
minio-py 7.0.0 has "Lots of APIs and functions been refactored", and …

### DIFF
--- a/dockerfiles/nix-channels/Dockerfile
+++ b/dockerfiles/nix-channels/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Wang Ruikang <dramforever@live.com>
 
 RUN apt-get update && \
     apt-get install -y python3-dev python3-pip curl && \
-    pip3 install pyquery requests minio && \
+    pip3 install pyquery requests minio==6.0.2 && \
     # Install Nix. To simplify management we only copy binaries and create
     # symlinks, and do no further configuration
     curl https://mirrors.tuna.tsinghua.edu.cn/nix/nix-2.3.2/nix-2.3.2-x86_64-linux.tar.xz -o /tmp/nix.tar.xz && \


### PR DESCRIPTION
…breaks current sync script.

Ref to https://github.com/ustclug/ustcmirror-images/commit/bf39c0e5d5c92099b2ae1ad6d84c4e53a387c0d4

taoky: minio-py 的大版本更新 break 了一些 API，然后 Dockerfile 里面 pip 安装的时候没有 pin minio 的版本。