### PR TITLE
nix-channels: Check release is complete before GC

### DIFF
--- a/nix-channels.py
+++ b/nix-channels.py
@@ -372,6 +372,9 @@ def garbage_collect():
     alive = set()
 
     for release in (working_dir / RELEASES_DIR).iterdir():
+        # This release never finished downloading
+        if (release / 'binary-cache-url').exists(): continue
+
         channel = release.name.split('@')[0]
         date_str = (release / '.released-time').read_text()
         released_date = datetime.strptime(date_str, '%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
Assumes that the existence of binary-cache-url indicates that a release
is completely downloaded, because it is the last file written when in
the clone_channels function.