### PR TITLE
nix-channels: fix critical bug in #115

### DIFF
--- a/nix-channels.py
+++ b/nix-channels.py
@@ -373,7 +373,7 @@ def garbage_collect():
 
     for release in (working_dir / RELEASES_DIR).iterdir():
         # This release never finished downloading
-        if (release / 'binary-cache-url').exists(): continue
+        if not (release / 'binary-cache-url').exists(): continue
 
         channel = release.name.split('@')[0]
         date_str = (release / '.released-time').read_text()


### PR DESCRIPTION
if binary-cache-url exists, it means that this repo has been completely downloaded, and should be considered as a candidate of "alive"

See https://github.com/tuna/tunasync-scripts/pull/115#pullrequestreview-578937481-permalink