### PR TITLE
[julia] switch upstreams to pkg servers

### DIFF
--- a/julia.sh
+++ b/julia.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
-BASE_URL=${TUNASYNC_UPSTREAM_URL:-"https://us-east.storage.juliahub.com"}
+BASE_URL=${TUNASYNC_UPSTREAM_URL:-"https://us-east.pkg.julialang.com"}
 [[ -d "${TUNASYNC_WORKING_DIR}" ]]
 cd "${TUNASYNC_WORKING_DIR}"
 
-UPSTREAMS="[\"https://us-east.storage.juliahub.com\", \"https://kr.storage.juliahub.com\"]"
+UPSTREAMS="[\"https://us-east.pkg.julialang.com\", \"https://kr.pkg.julialang.com\"]"
 
 OUTPUT_DIR="$PWD/static"
 


### PR DESCRIPTION
The current storage server stops providing `/registry/$uuid/$hash` files so the mirror job fails at the start. By switching to pkg servers it should work right now but I'm not sure if it would still work in the future.

See also https://github.com/johnnychen94/StorageMirrorServer.jl/issues/19