### PR TITLE
Revert "[julia] switch upstreams to pkg servers"

### DIFF
--- a/julia.sh
+++ b/julia.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
-BASE_URL=${TUNASYNC_UPSTREAM_URL:-"https://us-east.pkg.julialang.com"}
+BASE_URL=${TUNASYNC_UPSTREAM_URL:-"https://us-east.storage.juliahub.com"}
 [[ -d "${TUNASYNC_WORKING_DIR}" ]]
 cd "${TUNASYNC_WORKING_DIR}"
 
-UPSTREAMS="[\"https://us-east.pkg.julialang.com\", \"https://kr.pkg.julialang.com\"]"
+UPSTREAMS="[\"https://us-east.storage.juliahub.com\", \"https://kr.storage.juliahub.com\"]"
 
 OUTPUT_DIR="$PWD/static"
 


### PR DESCRIPTION
Reverts tuna/tunasync-scripts#117

The issue (https://github.com/johnnychen94/StorageMirrorServer.jl/issues/19) is fixed already in the storage end, so reverting to the normal storage server as it performs better.