### PR TITLE
Add nvidia channel in anaconda

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -63,6 +63,7 @@ CONDA_CLOUD_REPOS = (
     "c4aarch64/linux-aarch64", "c4aarch64/noarch",
     "pytorch3d/linux-64", "pytorch3d/noarch",
     "idaholab/linux-64", "idaholab/noarch",
+    "nvidia/linux-64",
 )
 
 EXCLUDED_PACKAGES = (


### PR DESCRIPTION
It is required to use the nvidia channel to get the latest version of cudatoolkit.


Reference Links:
https://anaconda.org/nvidia/cudatoolkit
https://pytorch.org
