### PR TITLE
Update llvm-apt to include missing arch

### DIFF
--- a/llvm-apt.sh
+++ b/llvm-apt.sh
@@ -12,7 +12,7 @@ export REPO_SIZE_FILE=/tmp/reposize.$RANDOM
 
 for os in "xenial" "bionic" "focal" "stretch" "buster" "bullseye"; do
     prefix=llvm-toolchain-$os
-    "$apt_sync" --delete "$BASE_URL/$os" $prefix,$prefix-9,$prefix-10,$prefix-11,$prefix-12,$prefix-13 main amd64 "$BASE_PATH/$os"
+    "$apt_sync" --delete "$BASE_URL/$os" $prefix,$prefix-9,$prefix-10,$prefix-11,$prefix-12,$prefix-13 main amd64,i386,s390x "$BASE_PATH/$os"
 done
 
 echo "APT finished"


### PR DESCRIPTION
llvm-toolchain apt packages status:

| Mirror | Architectures |
| --- | --- |
| apt.llvm.org | amd64 i386 s390x |
| tuna | amd64 |

Add arch `i386` and `s390x` to tuna mirror in this patch.