### PR TITLE
elastic: add 8.x

### DIFF
--- a/elastic.sh
+++ b/elastic.sh
@@ -11,7 +11,7 @@ BASE_URL=${TUNASYNC_UPSTREAM_URL:-"https://artifacts.elastic.co"}
 BASE_PATH="${TUNASYNC_WORKING_DIR%/}"
 BASE_URL="${BASE_URL%/}"
 
-ELASTIC_VERSION=("5.x" "6.x" "7.x")
+ELASTIC_VERSION=("5.x" "6.x" "7.x" "8.x")
 
 YUM_PATH="${BASE_PATH}/yum"
 APT_PATH="${BASE_PATH}/apt"


### PR DESCRIPTION
According to https://www.elastic.co/blog/whats-new-elastic-8-0-0 , elastic have released version 8 of elastic stack.

Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html