### PR TITLE
增加Mercurial代码库相关的功能函数

### DIFF
--- a/git-repo.sh
+++ b/git-repo.sh
@@ -23,6 +23,47 @@ function checkout_repo() {
     git -C $TUNASYNC_WORKING_DIR show HEAD:repo > $TUNASYNC_WORKING_DIR/git-repo
 }
 
+# ---------------------------------------
+# 20220511 Add Function for Initing git-remote-hg Script
+# 2022 (C) LinuxBCKP
+# ---------------------------------------
+function init_git_remote_hg() {
+    mkdir /usr/bin
+    curl -o /usr/bin/git-remote-hg https://raw.githubusercontent.com/fingolfin/git-remote-hg/master/git-remote-hg
+    chmod +x /usr/bin/git-remote-hg
+    echo 'export PATH=/usr/bin:$PATH' >> ~/.bashrc
+    source ~/.bashrc
+    git config --global core.notesRef refs/notes/hg
+}
+
+# ---------------------------------------
+# 20220511 Add Function for Initing Mercurial Mirror
+# 2022 (C) LinuxBCKP
+# ---------------------------------------
+function repo_init_hg() {
+        HGUPSTREAM="hg::"${UPSTREAM}
+	git clone --mirror $HGUPSTREAM $TUNASYNC_WORKING_DIR
+}
+
+# ---------------------------------------
+# 20220511 Add Function for Updating Mercurial Mirror
+# 2022 (C) LinuxBCKP
+# ---------------------------------------
+function update_repo_git_hg() {
+        HGUPSTREAM="hg::"${UPSTREAM}
+	cd $TUNASYNC_WORKING_DIR
+	echo "==== SYNC repo.git START ===="
+	git remote set-url origin "$HGUPSTREAM"
+	/usr/bin/timeout -s INT 3600 git remote -v update -p
+	head=$(git remote show origin | awk '/HEAD branch:/ {print $NF}')
+	[[ -n "$head" ]] && echo "ref: refs/heads/$head" > HEAD
+	git repack -a -b -d
+	sz=$(git count-objects -v|grep -Po '(?<=size-pack: )\d+')
+	sz=$(($sz*1024))
+	echo "Total size is" $(numfmt --to=iec $sz)
+	echo "==== SYNC repo.git DONE ===="
+}
+
 if [[ ! -f "$TUNASYNC_WORKING_DIR/HEAD" ]]; then
 	echo "Initializing repo.git mirror"
 	repo_init


### PR DESCRIPTION
1.增加同步Mercurial代码库的先决条件函数：init_git_remote_hg()，用于初始化依赖脚本、更新git设置等。此函数只需调用一次即可，无需每次同步Mercurial代码库都调用。
2.增加repo_init()函数的Mercurial适用版本：repo_init_hg()
3.增加update_repo_git()函数的Mercurial适用版本：update_repo_git_hg()
4.由于Mercurial支持MultipleHeads，所以出于防止歧义的考虑，我没法实现checkout_repo()函数的Mercurial适用版本。MultipleHeads的链接详见：https://www.mercurial-scm.org/wiki/MultipleHeads