### PR TITLE
Adoptium: change centos to rhel for long term support rpm

### DIFF
--- a/adoptium.py
+++ b/adoptium.py
@@ -119,6 +119,19 @@ if __name__ == "__main__":
         check=True)
     print("APT finished", flush=True)
     # =================== YUM repos ==========================
+    # "$yum_sync" "${BASE_URL}/rpm/centos/@{os_ver}/@{arch}" 7 Adopitum x86_64,aarch64 "centos@{os_ver}-@{arch}" "$BASE_PATH/rpm"
+    sp.run([str(here/"yum-sync.py"),
+        BASE_URL+'/rpm/centos/@{os_ver}/@{arch}',
+        "--download-repodata",
+        '7',
+        'Adoptium',
+        'x86_64,aarch64',
+        "centos@{os_ver}-@{arch}",
+        f"{BASE_PATH}/rpm"
+        ],
+        check=True) 
+
+    # =================== YUM repos ==========================
     # "$yum_sync" "${BASE_URL}/rpm/rhel/@{os_ver}/@{arch}" 7 Adopitum x86_64,aarch64 "rhel@{os_ver}-@{arch}" "$BASE_PATH/rpm"
     sp.run([str(here/"yum-sync.py"),
         BASE_URL+'/rpm/rhel/@{os_ver}/@{arch}',

--- a/adoptium.py
+++ b/adoptium.py
@@ -119,14 +119,14 @@ if __name__ == "__main__":
         check=True)
     print("APT finished", flush=True)
     # =================== YUM repos ==========================
-    # "$yum_sync" "${BASE_URL}/rpm/centos/@{os_ver}/@{arch}" 7 Adopitum x86_64,aarch64 "centos@{os_ver}-@{arch}" "$BASE_PATH/rpm"
+    # "$yum_sync" "${BASE_URL}/rpm/rhel/@{os_ver}/@{arch}" 7 Adopitum x86_64,aarch64 "rhel@{os_ver}-@{arch}" "$BASE_PATH/rpm"
     sp.run([str(here/"yum-sync.py"),
-        BASE_URL+'/rpm/centos/@{os_ver}/@{arch}',
+        BASE_URL+'/rpm/rhel/@{os_ver}/@{arch}',
         "--download-repodata",
-        '7',
+        '7,8,9',
         'Adoptium',
         'x86_64,aarch64',
-        "centos@{os_ver}-@{arch}",
+        "rhel@{os_ver}-@{arch}",
         f"{BASE_PATH}/rpm"
         ],
         check=True)


### PR DESCRIPTION
 Adoptium's RPM buids update for rhel 7,8, and 9, only update for centos 7. suggest to change centos to rhel. 

https://github.com/taomaree/tunasync-scripts/commit/631e91d01cfdad785bf96a3584f585277189b805