### PR TITLE
anaconda: add nvidia repo sync

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -38,6 +38,7 @@ CONDA_CLOUD_REPOS = (
     "pytorch/linux-64", "pytorch/osx-64", "pytorch/osx-arm64", "pytorch/win-64", "pytorch/win-32", "pytorch/noarch",
     "pytorch-lts/linux-64", "pytorch-lts/win-64", "pytorch-lts/noarch",
     "pytorch-test/linux-64", "pytorch-test/osx-64", "pytorch-test/win-64", "pytorch-test/win-32", "pytorch-test/noarch",
+    "nvidia/linux-64", "nvidia/linux-aarch64", "nvidia/win-64", "nvidia/noarch",
     "stackless/linux-64", "stackless/win-64", "stackless/win-32", "stackless/linux-32", "stackless/osx-64", "stackless/noarch",
     "fermi/linux-64", "fermi/osx-64", "fermi/win-64", "fermi/noarch",
     "fastai/linux-64", "fastai/osx-64", "fastai/win-64", "fastai/noarch",


### PR DESCRIPTION
The official installation script of PyTorch requires content from nvidia channel.