### PR TITLE
Allow centos 8-stream to be mirrored

### DIFF
--- a/yum-sync.py
+++ b/yum-sync.py
@@ -153,7 +153,7 @@ def main():
                         help='download repodata files instead of generating them')
     args = parser.parse_args()
 
-    if '-' in args.os_version:
+    if '-' in args.os_version and '-stream' not in args.os_version:
         dash = args.os_version.index('-')
         os_list = [ str(i) for i in range(
             int(args.os_version[:dash]),


### PR DESCRIPTION
Since the current CentOS 8 repositories are now under http://mirror.centos.org/centos/8-stream/ we need to be able to download/mirror this repository. When using `8-stream` the script fails as it tries to evaluate stream as an integer making a range from `8` to `stream` which doesn't make sense obviously.

I did this locally and was able to mirror the `8-stream` repos. Just figured someone might also need that :smile:  Let me know if and where to add tests.